### PR TITLE
Implement Multi-Collo support

### DIFF
--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -67,6 +67,36 @@ abstract class AbstractEndpoint
     }
 
     /**
+     * @param array $body
+     * @return AbstractCollection
+     * @throws ApiException
+     */
+    protected function restCreateCollection(array $body)
+    {
+        $result = $this->client->performHttpCall(
+            self::REST_CREATE,
+            $this->getResourcePath(),
+            $this->parseRequestBody($body)
+        );
+
+        /** @var AbstractCollection $collection */
+        $collection = $this->getResourceCollectionObject(
+            null,
+            null
+        );
+
+        if (is_object($result)) {
+            $result = $result->{$collection->getCollectionResourceName()};
+        }
+
+        foreach ($result as $dataResult) {
+            $collection[] = ResourceFactory::createFromApiResult($dataResult, $this->getResourceObject());
+        }
+
+        return $collection;
+    }
+
+    /**
      * @param       $id
      * @param array $filters
      * @return AbstractResource

--- a/src/Endpoints/ParcelMultiEndpoint.php
+++ b/src/Endpoints/ParcelMultiEndpoint.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Imbue\SendCloud\Endpoints;
+
+use Imbue\SendCloud\Exceptions\ApiException;
+use Imbue\SendCloud\Resources\Collections\ParcelCollection;
+use Imbue\SendCloud\Resources\GenericStatus;
+use Imbue\SendCloud\Resources\Parcel;
+use Imbue\SendCloud\Resources\ParcelMulti;
+use Imbue\SendCloud\Resources\ResourceFactory;
+
+class ParcelMultiEndpoint extends AbstractEndpoint
+{
+    /** @var string */
+    protected $resourcePath = 'parcels';
+
+    /**
+     * @return Parcel
+     */
+    protected function getResourceObject(): Parcel
+    {
+        return new Parcel($this->client);
+    }
+
+    /**
+     * @param $previous
+     * @param $next
+     * @return ParcelCollection
+     */
+    protected function getResourceCollectionObject($previous, $next): ParcelCollection
+    {
+        return new ParcelCollection($this->client, $previous, $next);
+    }
+
+    /**
+     * @param array $data
+     * @return ParcelCollection
+     * @throws ApiException
+     */
+    public function create(array $data = []): ParcelCollection
+    {
+        return $this->restCreateCollection($data);
+    }
+}

--- a/src/Endpoints/ShippingProductsEndpoint.php
+++ b/src/Endpoints/ShippingProductsEndpoint.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Imbue\SendCloud\Endpoints;
+
+use Imbue\SendCloud\Exceptions\ApiException;
+use Imbue\SendCloud\Resources\AbstractResource;
+use Imbue\SendCloud\Resources\Collections\AbstractCollection;
+use Imbue\SendCloud\Resources\Collections\ShippingProductCollection;
+use Imbue\SendCloud\Resources\ShippingProduct;
+
+class ShippingProductsEndpoint extends AbstractEndpoint
+{
+    /** @var string */
+    protected $resourcePath = 'shipping_products';
+    /** @var string */
+    protected $singleResourceKey = 'shipping_product';
+
+    /**
+     * @return mixed
+     */
+    protected function getResourceObject(): ShippingProduct
+    {
+        return new ShippingProduct($this->client);
+    }
+
+    /**
+     * @return ShippingProductCollection
+     */
+    protected function getResourceCollectionObject(): ShippingProductCollection
+    {
+        return new ShippingProductCollection(null, null);
+    }
+
+    /**
+     * @param       $id
+     * @param array $filters
+     * @return AbstractResource
+     * @throws ApiException
+     */
+    public function get($id, array $filters = [])
+    {
+        return $this->restRead($id, $filters);
+    }
+
+    /**
+     * @param $filters
+     * @return array|AbstractCollection
+     * @throws ApiException
+     */
+    public function list(array $filters = [])
+    {
+        return $this->restList($filters);
+    }
+}

--- a/src/Endpoints/ShippingProductsEndpoint.php
+++ b/src/Endpoints/ShippingProductsEndpoint.php
@@ -11,7 +11,7 @@ use Imbue\SendCloud\Resources\ShippingProduct;
 class ShippingProductsEndpoint extends AbstractEndpoint
 {
     /** @var string */
-    protected $resourcePath = 'shipping_products';
+    protected $resourcePath = 'shipping-products';
     /** @var string */
     protected $singleResourceKey = 'shipping_product';
 
@@ -39,7 +39,7 @@ class ShippingProductsEndpoint extends AbstractEndpoint
      */
     public function get($id, array $filters = [])
     {
-        return $this->restRead($id, $filters);
+        return $this->list($filters)->getArrayCopy()->get($id);
     }
 
     /**
@@ -50,5 +50,4 @@ class ShippingProductsEndpoint extends AbstractEndpoint
     public function list(array $filters = [])
     {
         return $this->restList($filters);
-    }
-}
+    }}

--- a/src/Resources/AvailableShippingFunctionality.php
+++ b/src/Resources/AvailableShippingFunctionality.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Imbue\SendCloud\Resources;
+
+class AvailableShippingFunctionality
+{
+    /** @var (null|int)[] */
+    public $age_check;
+
+    /** @var bool[] */
+    public $b2b;
+
+    /** @var bool[] */
+    public $b2c;
+
+    /** @var bool[] */
+    public $boxable;
+
+    /** @var bool[] */
+    public $bulky_goods;
+
+    /** @var (null|string)[] */
+    public $carrier_billing_type;
+
+    /** @var (null|bool)[] */
+    public $cash_on_delivery;
+
+    /** @var bool[] */
+    public $dangerous_goods;
+
+    /** @var (null|int)[] */
+    public $delivery_attempts;
+
+    /** @var (null|string)[] */
+    public $delivery_before;
+
+    /** @var (null|string)[] */
+    public $delivery_deadline;
+
+    /** @var bool[] */
+    public $direct_contract_only;
+
+    /** @var bool[] */
+    public $eco_delivery;
+
+    /** @var bool[] */
+    public $ers;
+
+    /** @var (null|string)[] */
+    public $first_mile;
+
+    /** @var bool[] */
+    public $flex_delivery;
+
+    /** @var (null|string)[] */
+    public $form_factor;
+
+    /** @var bool[] */
+    public $fragile_goods;
+
+    /** @var bool[] */
+    public $fresh_goods;
+
+    /** @var bool[] */
+    public $harmonized_label;
+
+    /** @var bool[] */
+    public $id_check;
+
+    /** @var (null|string)[] */
+    public $incoterm;
+
+    /** @var (null|int)[] */
+    public $insurance;
+
+    /** @var bool[] */
+    public $labelless;
+
+    /** @var (null|string)[] */
+    public $last_mile;
+
+    /** @var bool[] */
+    public $manually;
+
+    /** @var bool[] */
+    public $multicollo;
+
+    /** @var bool[] */
+    public $neighbor_delivery;
+
+    /** @var bool[] */
+    public $non_conveyable;
+
+    /** @var bool[] */
+    public $personalized_delivery;
+
+    /** @var bool[] */
+    public $premium;
+
+    /** @var (null|string)[] */
+    public $priority;
+
+    /** @var bool[] */
+    public $registered_delivery;
+
+    /** @var bool[] */
+    public $returns;
+
+    /** @var (null|string)[] **/
+    public $segment;
+
+    /** @var (null|string)[] */
+    public $service_area;
+
+    /** @var bool[] */
+    public $signature;
+
+    /** @var (null|string)[] */
+    public $size;
+
+    /** @var bool[] */
+    public $sorted;
+
+    /** @var bool[] */
+    public $surcharge;
+
+    /** @var bool[] */
+    public $tracked;
+
+    /** @var bool[] */
+    public $tyres;
+
+    /** @var (null|string)[] */
+    public $weekend_delivery;
+}

--- a/src/Resources/Collections/ShippingProductCollection.php
+++ b/src/Resources/Collections/ShippingProductCollection.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Imbue\SendCloud\Resources\Collections;
+
+use Imbue\SendCloud\Resources\ShippingProduct;
+
+class ShippingProductCollection extends AbstractCollection
+{
+    /**
+     * @return string
+     */
+    public function getCollectionResourceName()
+    {
+        return 'shipping_products';
+    }
+
+    /**
+     * @return ShippingProduct
+     */
+    protected function createResourceObject(): ShippingProduct
+    {
+        return new ShippingProduct($this->client);
+    }
+}

--- a/src/Resources/Parcel.php
+++ b/src/Resources/Parcel.php
@@ -78,4 +78,6 @@ class Parcel extends AbstractResource
     public $tracking_url;
     /** @var string */
     public $country_state;
+    /** @var int */
+    public $quantity;
 }

--- a/src/Resources/ShippingProduct.php
+++ b/src/Resources/ShippingProduct.php
@@ -2,7 +2,7 @@
 
 namespace Imbue\SendCloud\Resources;
 
-class ShippingProduct
+class ShippingProduct extends AbstractResource
 {
     /** @var string */
     public $name;
@@ -22,6 +22,6 @@ class ShippingProduct
     /** @var AvailableShippingFunctionality[] */
     public $available_functionalities;
 
-    /** @var ShippingMethod[] */
+    /** @var ShippingProductMethod[] */
     public $methods;
 }

--- a/src/Resources/ShippingProduct.php
+++ b/src/Resources/ShippingProduct.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Imbue\SendCloud\Resources;
+
+class ShippingProduct
+{
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $code;
+
+    /** @var string */
+    public $carrier;
+
+    /** @var string */
+    public $service_points_carrier;
+
+    /** @var WeightRange */
+    public $weight_range;
+
+    /** @var AvailableShippingFunctionality[] */
+    public $available_functionalities;
+
+    /** @var ShippingMethod[] */
+    public $methods;
+}

--- a/src/Resources/ShippingProductMethod.php
+++ b/src/Resources/ShippingProductMethod.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Imbue\SendCloud\Resources;
+
+class ShippingProductMethod
+{
+    /** @var int */
+    public $id;
+
+    /** @var string */
+    public $name;
+
+    /** @var AvailableShippingFunctionality */
+    public $functionalities;
+
+    /** @var string */
+    public $shippingProductCode;
+
+    /** @var ShippingProductMethodProperties */
+    public $properties;
+
+    /** @var object */
+    public $leadTimeHours;
+}

--- a/src/Resources/ShippingProductMethodProperties.php
+++ b/src/Resources/ShippingProductMethodProperties.php
@@ -2,11 +2,15 @@
 
 namespace Imbue\SendCloud\Resources;
 
-class WeightRange
+class ShippingProductMethodProperties
 {
     /** @var int */
     public $min_weight;
 
     /** @var int */
     public $max_weight;
+
+    /** @var ShippingProductMethodPropertiesMaxDimensions */
+    public $max_dimensions;
 }
+

--- a/src/Resources/ShippingProductMethodPropertiesMaxDimensions.php
+++ b/src/Resources/ShippingProductMethodPropertiesMaxDimensions.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Imbue\SendCloud\Resources;
+
+class ShippingProductMethodPropertiesMaxDimensions
+{
+    /** @var int */
+    public $length;
+
+    /** @var int */
+    public $width;
+
+    /** @var int */
+    public $height;
+
+    /** @var string */
+    public $unit;
+}

--- a/src/Resources/WeightRange.php
+++ b/src/Resources/WeightRange.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Imbue\SendCloud\Resources;
+
+class WeightRange
+{
+    /** @var int */
+    public $minWeight;
+
+    /** @var int */
+    public $maxWeight;
+}

--- a/src/SendCloudApiClient.php
+++ b/src/SendCloudApiClient.php
@@ -21,7 +21,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class SendCloudApiClient
 {
-    public const CLIENT_VERSION = '0.2.0';
+    public const CLIENT_VERSION = '1.1.0';
     public const API_ENDPOINT = 'https://panel.sendcloud.sc/api';
     public const API_VERSION = 'v2';
 

--- a/src/SendCloudApiClient.php
+++ b/src/SendCloudApiClient.php
@@ -15,6 +15,7 @@ use Imbue\SendCloud\Endpoints\ParcelEndpoint;
 use Imbue\SendCloud\Endpoints\ParcelStatusEndpoint;
 use Imbue\SendCloud\Endpoints\SenderAddressEndpoint;
 use Imbue\SendCloud\Endpoints\ShippingMethodEndpoint;
+use Imbue\SendCloud\Endpoints\ShippingProductsEndpoint;
 use Imbue\SendCloud\Endpoints\UserEndpoint;
 use Imbue\SendCloud\Exceptions\ApiException;
 use Psr\Http\Message\ResponseInterface;
@@ -58,6 +59,8 @@ class SendCloudApiClient
     public $parcelStatuses;
     /** @var ShippingMethodEndpoint */
     public $shippingMethods;
+    /** @var ShippingProductsEndpoint */
+    public $shippingProducts;
     /** @var LabelEndpoint */
     public $labels;
     /** @var InvoiceEndpoint */
@@ -97,6 +100,7 @@ class SendCloudApiClient
         $this->parcels = new ParcelEndpoint($this);
         $this->parcelStatuses = new ParcelStatusEndpoint($this);
         $this->shippingMethods = new ShippingMethodEndpoint($this);
+        $this->shippingProducts = new ShippingProductsEndpoint($this);
         $this->senderAddresses = new SenderAddressEndpoint($this);
         $this->labels = new LabelEndpoint($this);
         $this->invoices = new InvoiceEndpoint($this);

--- a/src/SendCloudApiClient.php
+++ b/src/SendCloudApiClient.php
@@ -12,6 +12,7 @@ use Imbue\SendCloud\Endpoints\IntegrationShipmentEndpoint;
 use Imbue\SendCloud\Endpoints\InvoiceEndpoint;
 use Imbue\SendCloud\Endpoints\LabelEndpoint;
 use Imbue\SendCloud\Endpoints\ParcelEndpoint;
+use Imbue\SendCloud\Endpoints\ParcelMultiEndpoint;
 use Imbue\SendCloud\Endpoints\ParcelStatusEndpoint;
 use Imbue\SendCloud\Endpoints\SenderAddressEndpoint;
 use Imbue\SendCloud\Endpoints\ShippingMethodEndpoint;
@@ -55,6 +56,8 @@ class SendCloudApiClient
 
     /** @var ParcelEndpoint */
     public $parcels;
+    /** @var ParcelMultiEndpoint */
+    public $parcelsMulti;
     /** @var ParcelStatusEndpoint */
     public $parcelStatuses;
     /** @var ShippingMethodEndpoint */
@@ -98,6 +101,7 @@ class SendCloudApiClient
     public function initializeEndpoints()
     {
         $this->parcels = new ParcelEndpoint($this);
+        $this->parcelsMulti = new ParcelMultiEndpoint($this);
         $this->parcelStatuses = new ParcelStatusEndpoint($this);
         $this->shippingMethods = new ShippingMethodEndpoint($this);
         $this->shippingProducts = new ShippingProductsEndpoint($this);


### PR DESCRIPTION
This PR adds support for creating multi-collo shipments in Sendcloud.

- Adds ParcelMultiEndpoint for creating multi shipments
- Adds a rest create method to AbstractEndpoint which returns a collection
- Adds ShippingProduct end-point for searching services and their capabilities to determine if multicollo (and many other) service options are available.